### PR TITLE
[RFR] Fix button classes

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -88,7 +88,7 @@ class Button(Widget, ClickableMixin):
         self.kwargs = kwargs
         classes = kwargs.pop('classes', [])
         if text:
-            if kwargs and kwargs.keys():
+            if kwargs:  # classes should have been the only kwarg combined with text args
                 raise TypeError('If you pass button text then only pass classes in addition')
             if len(text) == 1:
                 self.locator_conditions = 'normalize-space(.)={}'.format(quote(text[0]))

--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -86,9 +86,10 @@ class Button(Widget, ClickableMixin):
         Widget.__init__(self, parent, logger=logger)
         self.args = text
         self.kwargs = kwargs
+        classes = kwargs.pop('classes', [])
         if text:
-            if kwargs and 'classes' not in kwargs:
-                raise TypeError('If you pass button text then do not pass anything else.')
+            if kwargs and kwargs.keys():
+                raise TypeError('If you pass button text then only pass classes in addition')
             if len(text) == 1:
                 self.locator_conditions = 'normalize-space(.)={}'.format(quote(text[0]))
             elif len(text) == 2 and text[0].lower() == 'contains':
@@ -99,7 +100,7 @@ class Button(Widget, ClickableMixin):
             # Join the kwargs, if any
             self.locator_conditions = ' and '.join(
                 '@{}={}'.format(attr, quote(value)) for attr, value in kwargs.items())
-        classes = kwargs.pop('classes', [])
+
         if classes:
             self.locator_conditions += ' and '
             self.locator_conditions += ' and '.join(

--- a/testing/test_buttons.py
+++ b/testing/test_buttons.py
@@ -8,8 +8,10 @@ def test_button_click(browser):
         any_button = Button()
         button1 = Button('Default Normal')
         button2 = Button(title='Destructive title')
+        button3 = Button(title='noText', classes=[Button.PRIMARY])
 
     view = TestView(browser)
     assert view.any_button.is_displayed
     assert view.button1.is_displayed
     assert view.button2.is_displayed
+    assert view.button3.is_displayed

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -22,6 +22,7 @@
       <button class="btn btn-default" type="button">Default Normal</button>
       <button class="btn btn-primary" type="button">Primary Normal</button>
       <button class="btn btn-danger" type="button" title="Destructive title">Destructive</button>
+      <button class="btn btn-primary" type="button" title="noText">noText</button>
     </p>
     <p>
       <button class="btn btn-default btn-lg " type="button">Secondary Large</button>


### PR DESCRIPTION
Tested locally, the new tests fail before the change to moving `kwargs.pop('classes')` up in __init__.

Core failure was that when text is not supplied, the generator at L101/102 would pull kwargs[classes] and try to parse it into locator conditions as with the other attributes.  This fails because classes is not a standard button element attribute, and is handled in a separate block (passed as a list, not a string).

This was found during testing of MIQ pages where there is a dynamic table, and potentially multiple 'Add' buttons.  Defining a button with a mix of classes and attributes, with no text, produces an exception when the string formatting tries to call String.replace() on a list (classes).

# Travis Results
* The about modal test failed, that's expected. 
* The button test, with new widget and assertion, passes.