### PR TITLE
[RFR] Tab's ROOT doesn't point out to its contents

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -597,7 +597,8 @@ class Tab(View, ClickableMixin):
     TAB_NAME = None
     INDIRECT = True
     ROOT = ParametrizedLocator(
-        './/ul[contains(@class, "nav-tabs")]/li[normalize-space(.)={@tab_name|quote}]')
+        './/ul[contains(@class, "nav-tabs") and ./li[normalize-space(.)={@tab_name|quote}]]'
+        '/following-sibling::div[contains(@class, "tab-content")]')
 
     @property
     def tab_name(self):


### PR DESCRIPTION
Widgets under Tab cannot be found due to that issue. 
(This issue wasn't encountered before because parent of parent wasn't passed correctly)