### PR TITLE
[RFR] BootstrapSwitch incorrect gets switch state in some cases

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -1463,7 +1463,15 @@ class BootstrapSwitch(BaseInput):
 
     @property
     def selected(self):
-        return self.browser.is_selected(self)
+        # it seems there is a bug in patternfly lib because in some cases
+        # BootstrapSwitch->input.checked returns False when control is definitely checked
+        classes = self.browser.classes(self)
+        if 'ng-not-empty' in classes:
+            return True
+        elif 'ng-empty' in classes:
+            return False
+        else:
+            return self.browser.is_selected(self)
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
It seems this is patternfly or manageiq bug. 
For example there is BootstrapSwitch on Middleware->Servers->Add Deployment page, it is in "on" state by default but selenium's is_selected method will return False until it gets clicked.
The issue can be noticed in JS as well.
el = document.getElementById('force_deployment_cb')
el.checked (returns False though it is True)

This PR is a workaround for above issue.

Found by @hhovsepy