### PR TITLE
[RFR]removed dot from PARTIAL match locator

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -760,7 +760,7 @@ class BootstrapSelect(Widget, ClickableMixin):
     ROOT = ParametrizedLocator('{@locator}')
     BY_VISIBLE_TEXT = '//div/ul/li/a[./span[contains(@class, "text") and normalize-space(.)={}]]'
     BY_PARTIAL_VISIBLE_TEXT = (
-        './/div/ul/li/a[./span[contains(@class, "text") and contains(normalize-space(.), {})]]')
+        '//div/ul/li/a[./span[contains(@class, "text") and contains(normalize-space(.), {})]]')
 
     def __init__(
             self, parent, id=None, name=None, locator=None, can_hide_on_select=False, logger=None):


### PR DESCRIPTION
New 5.9 build is not selecting dropdown values from partial_match(vlan) .
@mfalesni : please review.
It works with 5.8 build too - I have tested for my test .