### PR TITLE
Fix Tab.is_displayed

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -670,6 +670,10 @@ class Tab(View):
     def is_disabled(self):
         return 'disabled' in self.parent_browser.classes(self.TAB_LOCATOR)
 
+    @property
+    def is_displayed(self):
+        return self.parent_browser.is_displayed(self.TAB_LOCATOR)
+
     def click(self):
         return self.parent_browser.click(self.TAB_LOCATOR)
 


### PR DESCRIPTION
Removing the ROOT also removed the is_displayed functionality.