### PR TITLE
[RFR]warning should not count as error

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -221,7 +221,7 @@ class FlashMessages(Widget):
     def assert_no_error(self):
         self.logger.info('asserting there are no error messages')
         for message in self.messages:
-            if message.type not in {'success', 'info'}:
+            if message.type not in {'success', 'info', 'warning'}:
                 self.logger.error('%s: %r', message.type, message.text)
                 raise AssertionError('assert_no_error: {}: {}'.format(message.type, message.text))
             else:


### PR DESCRIPTION
In `assert_no_error()` method, flash message type `warning` should not count as error.
for more clarification adding one example[0]

[0] http://pastebin.test.redhat.com/575839