### PR TITLE
Added another condition encountered when working with buttons

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -141,7 +141,8 @@ class Button(Widget, ClickableMixin):
     @property
     def disabled(self):
         return ('disabled' in self.browser.classes(self) or
-                self.browser.get_attribute('disabled', self) == 'disabled')
+                self.browser.get_attribute('disabled', self) == 'disabled' or
+                self.browser.get_attribute('disabled', self) == 'true')
 
     def __repr__(self):
         return '{}{}'.format(type(self).__name__, call_sig(self.args, self.kwargs))


### PR DESCRIPTION
I encountered this HTML for a button:

```<button disabled type="button" class="btn btn-primary">Save</button>```

which evaluates to: 

```<button type="button" class="btn btn-primary" disabled="">Save</button>```

In this situation, `self.browser.get_attribute('disabled', self)` results in `'true'` when disabled and `'false'` when enabled. The current code does not detect this and always marks it as false (enabled). This is to resolve that condition.

As an addition, setting `== 'disabled'` looks strange if the function outputs true or false (not Pythonic `True` or `False`, just strings). Is that supposed to be that way? If not, I can modify my commit to remove that condition.