### PR TITLE
[RFR] Add AggregateStatusCard widget and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,16 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-install: pip install tox-travis
+addons:
+  firefox: latest
+before_install:
+  # install geckdriver for firefox
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.22.0/geckodriver-v0.22.0-linux64.tar.gz
+  - mkdir geckodriver
+  - tar -xzvf geckodriver-v0.22.0-linux64.tar.gz -C geckodriver
+  - export PATH=$PATH:$PWD/geckodriver
+install:
+  - pip install tox-travis
 script: tox
 after_success:
 - coveralls

--- a/src/widgetastic_patternfly/utils.py
+++ b/src/widgetastic_patternfly/utils.py
@@ -11,7 +11,11 @@ class IconConstants(Constant):
     ADD = 'pficon-add-circle-o'
     APPLICATIONS = 'pficon-applications'
     ARROW = 'pficon-arrow'
+    CLUSTER = 'pficon-cluster'
+    CONTAINER_NODE = 'pficon-container-node'
+    CPU = 'pficon-cpu'
     ERROR = 'pficon-error-circle-o'
+    HOME = 'pficon-home'
     OK = 'pficon-ok'
     WARNING = 'pficon-warning-triangle-o'
     REFRESH = 'fa-refresh'
@@ -53,7 +57,7 @@ class PFIcon(object):
                       for c in browser.classes(els.pop())
                       if c.startswith('pficon-') or c.startswith('fa-')]
         # slice off first 6 chars if a class was found
-        icon_name = icon_class or None
+        icon_name = icon_class.pop() if icon_class else None
         icons = [
             getattr(cls.icons, attr, None)
             for attr, icon_string in cls.icons.icon_strings().items()

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -22,7 +22,9 @@ class CustomBrowser(Browser):
 
 @pytest.fixture(scope='session')
 def selenium(request):
-    driver = webdriver.PhantomJS()
+    options = webdriver.FirefoxOptions()
+    options.headless = True
+    driver = webdriver.Firefox(firefox_options=options)
     request.addfinalizer(driver.quit)
     driver.maximize_window()
     global selenium_browser
@@ -45,5 +47,12 @@ def browser(selenium, httpserver, request):
 def pytest_exception_interact(node, call, report):
     if selenium_browser is not None:
         allure.attach(
-            'Error screenshot', selenium_browser.get_screenshot_as_png(), allure.attach_type.PNG)
-        allure.attach('Error traceback', str(report.longrepr), allure.attach_type.TEXT)
+            selenium_browser.get_screenshot_as_png(),
+            'Error screenshot',
+            allure.attachment_type.PNG
+        )
+        allure.attach(
+            str(report.longrepr),
+            'Error traceback',
+            allure.attachment_type.TEXT
+        )

--- a/testing/test_agg_status_card.py
+++ b/testing/test_agg_status_card.py
@@ -1,0 +1,67 @@
+import pytest
+
+from widgetastic.exceptions import LocatorNotImplemented
+from widgetastic.widget import View
+from widgetastic_patternfly import AggregateStatusCard
+from widgetastic_patternfly.utils import PFIcon
+
+
+def test_agg_status_card_read(browser):
+    """Test Aggregate Status Card reading number, title, notifications"""
+
+    class TestAggView(View):
+        agg_card_ip = AggregateStatusCard(name='Ipsum', action_title='Add Ipsum')
+        agg_card_amet = AggregateStatusCard(name='Amet')
+        agg_card_adi = AggregateStatusCard(name='Adipiscing')
+
+    view = TestAggView(browser)
+
+    # Display
+    for card in [view.agg_card_ip, view.agg_card_amet, view.agg_card_adi]:
+        assert card.is_displayed
+
+    # count
+    assert view.agg_card_ip.count == 0
+    assert view.agg_card_amet.count == 20
+    assert view.agg_card_adi.count is None
+
+    # Clickable body with title, or not
+    assert view.agg_card_ip.click_body_action() is None
+    for card in [view.agg_card_amet, view.agg_card_adi]:
+        with pytest.raises(LocatorNotImplemented):
+            card.click_body_action()
+
+    # title icons
+    for card in [view.agg_card_ip, view.agg_card_adi]:
+        assert card.icon == PFIcon.icons.HOME
+    assert view.agg_card_amet.icon is None
+
+    # notifications
+    ip_notes_expected = [
+        {'icon': PFIcon.icons.ADD, 'text': None}
+    ]
+    ip_notes = view.agg_card_ip.notifications
+    assert len(ip_notes) == 1
+    assert [n.read() for n in ip_notes] == ip_notes_expected
+
+    amet_notes_expected = [
+        {'icon': PFIcon.icons.ERROR, 'text': '4'},
+        {'icon': PFIcon.icons.WARNING, 'text': '1'}
+    ]
+    amet_notes = view.agg_card_amet.notifications
+    assert len(amet_notes) == 2
+    assert [n.read() for n in amet_notes] == amet_notes_expected
+
+    adi_notes_expected = [
+        {'icon': None, 'text': 'noclick'}
+    ]
+    adi_notes = view.agg_card_adi.notifications
+    assert len(adi_notes) == 1
+    assert [n.read() for n in adi_notes] == adi_notes_expected
+
+    assert view.agg_card_ip.read() == {
+        'icon': PFIcon.icons.HOME,
+        'count': 0,
+        'name': 'Ipsum',
+        'notifications': ip_notes_expected
+    }

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -70,55 +70,175 @@
 
 
 <!--------------------------------- Bootstrap-Datepicker------------------------------------------>
-<div class="datepicker_container" align="center" style="width: 300px; text-align:center">
-  <div class="datepicker_readonly">
-    <label class="control-label " for="date_readonly">
-      Bootstrap datepicker readonly
-    </label>
-    <input class="form-control" id="date_readonly" name="date_readonly" readonly="readonly" autoclose="true" placeholder="MM/DD/YYYY" data-date-format="mm/dd/yyyy" type="text"/>
-  </div>
-     
-  <div class="datepicker_readwrite">
-    <label class="control-label " for="date_readwrite">
-      Bootstrap datepicker readwrite
-    </label>
-    <input class="form-control" id="date_readwrite" name="date_readwrite" autoclose="true" placeholder="MM/DD/YYYY" data-date-format="mm/dd/yyyy" type="text"/>
-  </div>
-
-  <div class="patternfly_datepicker">
-      <label class="control-label " for="date_readwrite">
-        Patternfly Basic DatePicker
+  <div class="datepicker_container" align="center" style="width: 300px; text-align:center">
+    <div class="datepicker_readonly">
+      <label class="control-label " for="date_readonly">
+        Bootstrap datepicker readonly
       </label>
-      <input type="text" id="patternfly_dp" class="form-control bootstrap-datepicker" readonly><span class="input-group-addon"><span class="fa fa-calendar"></span></span>
-  </div>
-</div>  
+      <input class="form-control" id="date_readonly" name="date_readonly" readonly="readonly" autoclose="true" placeholder="MM/DD/YYYY" data-date-format="mm/dd/yyyy" type="text"/>
+    </div>
 
-<script>
-  $(document).ready(function(){
-    var date_in_readonly=$('input[name="date_readonly"]');
-    var date_in_readwrite=$('input[name="date_readwrite"]');
-    var date_in_patternfly=$('input[id="patternfly_dp"]')
-    //our date input has the name or id
-    var container=$('.bootstrap-iso form').length>0 ? $('.bootstrap-iso form').parent() : "body";
-    date_in_readonly.datepicker({
-        format: 'mm/dd/yyyy',
-        container: container,
-        todayHighlight: true,
+    <div class="datepicker_readwrite">
+      <label class="control-label " for="date_readwrite">
+        Bootstrap datepicker readwrite
+      </label>
+      <input class="form-control" id="date_readwrite" name="date_readwrite" autoclose="true" placeholder="MM/DD/YYYY" data-date-format="mm/dd/yyyy" type="text"/>
+    </div>
+
+    <div class="patternfly_datepicker">
+        <label class="control-label " for="date_readwrite">
+          Patternfly Basic DatePicker
+        </label>
+        <input type="text" id="patternfly_dp" class="form-control bootstrap-datepicker" readonly><span class="input-group-addon"><span class="fa fa-calendar"></span></span>
+    </div>
+  </div>
+
+  <script>
+    $(document).ready(function(){
+      var date_in_readonly=$('input[name="date_readonly"]');
+      var date_in_readwrite=$('input[name="date_readwrite"]');
+      var date_in_patternfly=$('input[id="patternfly_dp"]')
+      //our date input has the name or id
+      var container=$('.bootstrap-iso form').length>0 ? $('.bootstrap-iso form').parent() : "body";
+      date_in_readonly.datepicker({
+          format: 'mm/dd/yyyy',
+          container: container,
+          todayHighlight: true,
+          autoclose: true,
+      })
+      date_in_readwrite.datepicker({
+          format: 'mm/dd/yyyy',
+          todayHighlight: true,
+          autoclose: true,
+      })
+      date_in_patternfly.datepicker({
         autoclose: true,
-    })
-    date_in_readwrite.datepicker({
-        format: 'mm/dd/yyyy',
-        todayHighlight: true,
-        autoclose: true,
-    })
-    date_in_patternfly.datepicker({
-      autoclose: true,
-      orientation: "top auto",
-      todayBtn: "linked",
-      todayHighlight: true
-    });
-})
-</script>
+        orientation: "top auto",
+        todayBtn: "linked",
+        todayHighlight: true
+      });
+  })
+  </script>
 <!--------------------------------- Bootstrap-Datepicker End ------------------------------------>
-</body>
+
+<!--------------------------------- AggregateStatusCard ------------------------------------------>
+<!-- from reference
+markup: https://www.patternfly.org/pattern-library/cards/aggregate-status-card/#example-code-1 -->
+  <div class="cards-pf">
+    <div class="container-fluid container-cards-pf">
+      <div class="row row-cards-pf">
+        <div class="col-xs-6 col-sm-4 col-md-4">
+          <div class="card-pf card-pf-accented card-pf-aggregate-status">
+            <h2 class="card-pf-title">
+              <span class="pficon pficon-home"></span><span class="card-pf-aggregate-status-count">0</span> Ipsum
+            </h2>
+            <div class="card-pf-body">
+              <p class="card-pf-aggregate-status-notifications">
+                <span class="card-pf-aggregate-status-notification"><a href="#" class="add" data-toggle="tooltip" data-placement="top" title="Add Ipsum"><span class="pficon pficon-add-circle-o"></span></a></span>
+              </p>
+            </div>
+          </div>
+        </div>
+          <div class="col-xs-6 col-sm-4 col-md-4">
+            <div class="card-pf card-pf-accented card-pf-aggregate-status">
+              <h2 class="card-pf-title">
+                <a href="#"><span class="card-pf-aggregate-status-count">20</span> Amet</a>
+              </h2>
+              <div class="card-pf-body">
+                <p class="card-pf-aggregate-status-notifications">
+                  <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-error-circle-o"></span>4</a></span>
+                  <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-warning-triangle-o"></span>1</a></span>
+                </p>
+              </div>
+            </div>
+          </div>
+            <div class="col-xs-6 col-sm-4 col-md-4">
+              <div class="card-pf card-pf-accented card-pf-aggregate-status">
+                <h2 class="card-pf-title">
+                  <a href="#"><span class="pficon pficon-home"></span> Adipiscing</a>
+                </h2>
+                <div class="card-pf-body">
+                  <p class="card-pf-aggregate-status-notifications">
+                    <span class="card-pf-aggregate-status-notification"><span>noclick</span></span>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div><!-- /row -->
+        </div><!-- /container -->
+      <script src="/components/jquery-match-height/dist/jquery.matchHeight-min.js"></script>
+      <script>
+      $(function() {
+        // matchHeight the contents of each .card-pf and then the .card-pf itself
+        $(".row-cards-pf > [class*='col'] > .card-pf .card-pf-title").matchHeight();
+        $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
+        $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-footer").matchHeight();
+        $(".row-cards-pf > [class*='col'] > .card-pf").matchHeight();
+        // initialize tooltips
+        $('[data-toggle="tooltip"]').tooltip();
+      });
+      </script>
+  </div>
+<!--------------------------------- AggregateStatusCard Mini -------------------------------------->
+  <div class="cards-pf">
+    <div class="container-fluid container-cards-pf">
+      <div class="row row-cards-pf">
+        <div class="col-xs-6 col-sm-4 col-md-4">
+          <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini">
+            <h2 class="card-pf-title">
+              <span class="pficon pficon-cpu"></span>
+              <span class="card-pf-aggregate-status-count">0</span> Ipsum
+            </h2>
+            <div class="card-pf-body">
+              <p class="card-pf-aggregate-status-notifications">
+                <span class="card-pf-aggregate-status-notification"><a href="#" class="add" data-toggle="tooltip" data-placement="top" title="Add Ipsum"><span class="pficon pficon-add-circle-o"></span></a></span>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="col-xs-6 col-sm-4 col-md-4">
+          <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini">
+            <h2 class="card-pf-title">
+              <a href="#">
+                <span class="pficon pficon-cpu"></span>
+                <span class="card-pf-aggregate-status-count">20</span> Amet
+              </a>
+            </h2>
+            <div class="card-pf-body">
+              <p class="card-pf-aggregate-status-notifications">
+                <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-error-circle-o"></span>4</a></span>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="col-xs-6 col-sm-4 col-md-4">
+          <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini">
+            <h2 class="card-pf-title">
+              <a href="#">
+                <span class="pficon pficon-cpu"></span>
+                <span class="card-pf-aggregate-status-count">9</span> Adipiscing
+              </a>
+            </h2>
+            <div class="card-pf-body">
+              <p class="card-pf-aggregate-status-notifications">
+                <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div><!-- /row -->
+    </div><!-- /container -->
+    <script src="/components/jquery-match-height/dist/jquery.matchHeight-min.js"></script>
+    <script>
+      $(function() {
+        // matchHeight the contents of each .card-pf and then the .card-pf itself
+        $(".row-cards-pf > [class*='col'] > .card-pf .card-pf-title").matchHeight();
+        $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
+        $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-footer").matchHeight();
+        $(".row-cards-pf > [class*='col'] > .card-pf").matchHeight();
+        // initialize tooltips
+        $('[data-toggle="tooltip"]').tooltip();
+      });
+    </script>
+  </div>
 </html>

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,14 @@ envlist = py{27,34,35,36},codechecks
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-deps=
-    pytest<=2.9.0,>=2.7.3
-    pytest-allure-adaptor
+deps =
+    aenum
+    allure-pytest
+    coveralls
+    pytest
     pytest-localserver
     pytest-cov
-    coveralls
+    selenium
 commands =
     - py.test {posargs: -v --cov widgetastic_patternfly --cov-report term-missing --alluredir allure/}
     - coveralls


### PR DESCRIPTION
Adding widgets for Aggregate Status cards, per patternfly reference markup.

Making the locators modular, so that modifying them in application-specific widgets is easier.