### PR TITLE
[1LP][RFR] read method to Dropdown

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -1538,6 +1538,14 @@ class Dropdown(Widget):
             raise DropdownDisabled('Dropdown "{}" is not enabled'.format(self.text))
 
     @property
+    def currently_selected(self):
+        """Returns the currently selected item text."""
+        return self.browser.text(self.BUTTON_LOCATOR, parent=self)
+
+    def read(self):
+        return self.currently_selected
+
+    @property
     def is_open(self):
         return 'open' in self.browser.classes(self)
 
@@ -1670,17 +1678,9 @@ class SelectorDropdown(Dropdown):
         self.b_attr = button_attr
         self.b_attr_value = button_attr_value
 
-    @property
-    def currently_selected(self):
-        """Returns the currently selected item text."""
-        return self.browser.text(self.BUTTON_LOCATOR, parent=self)
-
     def item_select(self, item, *args, **kwargs):
         super(SelectorDropdown, self).item_select(item, *args, **kwargs)
         wait_for(lambda: self.currently_selected == item, num_sec=3, delay=0.2)
-
-    def read(self):
-        return self.currently_selected
 
     def fill(self, value):
         if value == self.currently_selected:


### PR DESCRIPTION
-  I observed that for `Dropdown` widget; we need method which will return `currently selected option`.
-  This type  of method is in `SelectedDropdown`. So change name of this method and moved to `Dropdown` class.
- Method name should be same for similar operation among all widgets. 

- We had used this in `SSUIDropdown`[0]. Now,  I need this for `custom button`. For checking the display option of `Group`. Objective is just check name display or not.

[0] https://github.com/ManageIQ/integration_tests/blob/master/widgetastic_manageiq/__init__.py#L1143