### PR TITLE
[RFR] Add unit test for BootstrapTreeview widget, and root_items property

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -1132,7 +1132,11 @@ class BootstrapTreeview(Widget):
 
     @property
     def root_item_count(self):
-        return len(self.browser.elements(self.ROOT_ITEMS, parent=self))
+        return len(self.root_items)
+
+    @property
+    def root_items(self):
+        return self.browser.elements(self.ROOT_ITEMS, parent=self)
 
     @property
     def root_item(self):

--- a/testing/test_bootstrap_tree.py
+++ b/testing/test_bootstrap_tree.py
@@ -1,0 +1,18 @@
+from widgetastic.widget import View
+from widgetastic_patternfly import BootstrapTreeview
+
+
+def test_bootstrap_tree(browser):
+    class TestView(View):
+        tree = BootstrapTreeview(tree_id="treeview1")
+
+    view = TestView(browser)
+
+    # assert that tree is visible
+    assert view.tree.is_displayed
+    # assert that we have multiple roots in this tree view
+    assert view.tree.root_item_count > 1
+    # assert that we have multiple root items
+    assert len(view.tree.root_items) > 1
+    # TODO: add more to the widget in testing page so that we can test more complex
+    #       functionality, such as currently_selected

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -17,6 +17,9 @@
   <!-- Include Date Picker -->
   <script type="text/javascript"    src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.4.1/js/bootstrap-datepicker.min.js"></script>
   <script src="components/bootstrap-datepicker/dist/js/bootstrap-datepicker.js"></script>
+  <!-- Include bootstrap treeview -->
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-treeview/1.2.0/bootstrap-treeview.min.js"></script>
+  <script src="components/bootstrap-treeview/dist/js/bootstrap-treeview.js"></script>
   <title>Patternfly testing page</title>
 </head>
 <body>
@@ -255,6 +258,77 @@ markup: https://www.patternfly.org/pattern-library/cards/aggregate-status-card/#
     </ul>
   </div>
   <label id="kebab_display">N/A</label>
+  <!----------------------------- BootstrapTreeview ----------------------------------------------->
+  <div class="pf-example">
+    <div id="treeview1"></div>
+    <script src="/components/patternfly-bootstrap-treeview/dist/bootstrap-treeview.min.js"></script>
+    <script>
+      $(function() {
+        var defaultData = [
+          {
+            text: 'Parent 1',
+            href: '#parent1',
+            tags: ['4'],
+            nodes: [
+              {
+                text: 'Child 1',
+                href: '#child1',
+                icon: 'fa fa-file-o',
+                tags: ['2'],
+                nodes: [
+                  {
+                    text: 'Grandchild 1',
+                    href: '#grandchild1',
+                    icon: 'fa fa-file-o',
+                    tags: ['0']
+                  },
+                  {
+                    text: 'Grandchild 2',
+                    href: '#grandchild2',
+                    icon: 'fa fa-file-o',
+                    tags: ['0']
+                  }
+                ]
+              },
+              {
+                text: 'Child 2',
+                href: '#child2',
+                icon: 'fa fa-file-o',
+                tags: ['0']
+              }
+            ]
+          },
+          {
+            text: 'Parent 2',
+            href: '#parent2',
+            tags: ['0']
+          },
+          {
+            text: 'Parent 3',
+            href: '#parent3',
+             tags: ['0']
+          },
+          {
+            text: 'Parent 4',
+            href: '#parent4',
+            tags: ['0']
+          },
+          {
+            text: 'Parent 5',
+            href: '#parent5'  ,
+            tags: ['0']
+          }
+        ];
+        $('#treeview1').treeview({
+          collapseIcon: "fa fa-angle-down",
+          data: defaultData,
+          expandIcon: "fa fa-angle-right",
+          nodeIcon: "fa fa-folder",
+          showBorder: false
+        });
+      });
+    </script>
+  </div>
 <script>
 function kebab_function(actionOne) {
 document.getElementById("kebab_display").innerHTML = actionOne;


### PR DESCRIPTION
The `BootstrapTreeview` widget currently has no support for trees which have more than one root. I propose that: 
1) We add a `root_items` property for this widget
2) Add a basic unit test for this widget. 