### PR TITLE
[RFR]: Add in modal widget with basic functionality

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -1935,12 +1935,6 @@ class Modal(View):
         ROOT = './/div[@class="modal-body"]'
         body_text = Text(locator=".//h4")
 
-        def fill(self, value):
-            if not self.form:
-                return False
-            else:
-                return self.form.fill(value)
-
     @View.nested
     class footer(View):  # noqa
         """ The footer of the modal """

--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -1897,8 +1897,8 @@ class Modal(View):
             'and contains(@class, "fade") and @role="dialog"]')
 
     def __init__(self, parent, id=None, logger=None):
+        self.id = id
         if id:
-            self.id = id
             self.ROOT = ParametrizedLocator(
                 './/div[normalize-space(@id)={@id|quote} and '
                 'contains(@class, "modal") and contains(@class, "fade") '

--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -1893,17 +1893,18 @@ class Modal(View):
 
         https://www.patternfly.org/pattern-library/widgets/#modal
     """
-    ROOT = ParametrizedLocator('.//div[normalize-space(@id)={@id|quote} and '
-                               'contains(@class, "modal") and contains(@class, "fade") '
-                               'and @role="dialog"]')
+    ROOT = ('.//div[contains(@class, "modal") '
+            'and contains(@class, "fade") and @role="dialog"]')
 
     def __init__(self, parent, id=None, logger=None):
+        if id:
+            self.id = id
+            self.ROOT = ParametrizedLocator(
+                './/div[normalize-space(@id)={@id|quote} and '
+                'contains(@class, "modal") and contains(@class, "fade") '
+                'and @role="dialog"]')
+
         View.__init__(self, parent, logger=logger)
-        self.id = id
-        if not self.id:
-            # if no id, we make assumptions about the modal's locator
-            self.ROOT = ('.//div[contains(@class, "modal") '
-                         'and contains(@class, "fade") and @role="dialog"]')
 
     @property
     def title(self):
@@ -1933,8 +1934,6 @@ class Modal(View):
         """ The body of the modal """
         ROOT = './/div[@class="modal-body"]'
         body_text = Text(locator=".//h4")
-        # form widget, this varies from modal to modal, so it is defaulted to None
-        form = None
 
         def fill(self, value):
             if not self.form:
@@ -1956,12 +1955,6 @@ class Modal(View):
     def accept(self):
         """ Submit/Save/Accept/Delete for the modal."""
         self.footer.accept.click()
-
-    def fill(self, value):
-        filled = self.body.fill(value)
-        if filled:
-            self.submit()
-        return filled
 
 
 class BreadCrumb(Widget):

--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -1911,6 +1911,11 @@ class Modal(View):
         return self.header.title.read()
 
     @property
+    def text(self):
+        """ Option for compatibility with selenium alerts """
+        return self.title
+
+    @property
     def is_displayed(self):
         """ Is the modal currently open? """
         try:
@@ -1920,7 +1925,7 @@ class Modal(View):
 
     def close(self):
         """Close the modal"""
-        self.header.close.click()
+        self.header.close.is_displayed and self.header.close.click()
 
     @View.nested
     class header(View):  # noqa

--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -1946,16 +1946,16 @@ class Modal(View):
     class footer(View):  # noqa
         """ The footer of the modal """
         ROOT = './/div[@class="modal-footer"]'
-        cancel = Button("Cancel")
-        submit = Button(classes=Button.PRIMARY)
+        dismiss = Button("Cancel")
+        accept = Button(classes=Button.PRIMARY)
 
     def dismiss(self):
         """ Cancel the modal"""
-        self.footer.cancel.click()
+        self.footer.dismiss.click()
 
     def accept(self):
         """ Submit/Save/Accept/Delete for the modal."""
-        self.footer.submit.click()
+        self.footer.accept.click()
 
     def fill(self, value):
         filled = self.body.fill(value)

--- a/testing/test_modal.py
+++ b/testing/test_modal.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from wait_for import wait_for
+
+from widgetastic.widget import View
+from widgetastic_patternfly import Modal, Button
+
+# Values from testing_page.html modal
+modal_id = 'myModal'
+title = 'Modal Title'
+
+
+def test_generic_modal(browser):
+    """
+    Test the modal, including all methods/properties
+
+    Test against modal defined in testing_page.html
+    :param browser: browser fixture
+    """
+    class TestView(View):
+        """ Dummy page matching testing_page.html elements"""
+        button = Button('Launch demo modal')
+        modal = Modal(id=modal_id)
+
+    view = TestView(browser)
+    assert not view.modal.is_displayed
+
+    # Open the modal
+    assert not view.button.disabled
+    view.button.click()
+    wait_for(lambda: view.modal.is_displayed, delay=0.5, num_sec=5)
+
+    assert view.modal.title == title
+
+    # close the modal via the "x"
+    view.modal.close()
+    view.flush_widget_cache()
+    wait_for(lambda: not view.modal.is_displayed, delay=0.5, num_sec=5)
+
+    # # open modal again
+    view.button.click()
+    wait_for(lambda: view.modal.is_displayed, delay=0.5, num_sec=5)
+    # make sure buttons are not disabled
+    assert not view.modal.footer.dismiss.disabled
+    assert not view.modal.footer.accept.disabled
+    # make sure the cancel button works
+    view.modal.dismiss()
+
+    wait_for(lambda: not view.modal.is_displayed, delay=0.1, num_sec=5)

--- a/testing/test_modal.py
+++ b/testing/test_modal.py
@@ -1,12 +1,23 @@
 # -*- coding: utf-8 -*-
 from wait_for import wait_for
 
+from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic_patternfly import Modal, Button
 
 # Values from testing_page.html modal
 modal_id = 'myModal'
 title = 'Modal Title'
+
+
+class SpecificModal(Modal):
+    """ Specific Modal class overwrites the body of Modal, since the form will vary. """
+
+    @View.nested
+    class body(View):  # noqa
+        field_one = TextInput(id="textInput-modal-markup")
+        field_two = TextInput(id="textInput2-modal-markup")
+        field_three = TextInput(id="textInput3-modal-markup")
 
 
 def test_generic_modal(browser):
@@ -16,10 +27,11 @@ def test_generic_modal(browser):
     Test against modal defined in testing_page.html
     :param browser: browser fixture
     """
+
     class TestView(View):
         """ Dummy page matching testing_page.html elements"""
         button = Button('Launch demo modal')
-        modal = Modal(id=modal_id)
+        modal = SpecificModal(id=modal_id)
 
     view = TestView(browser)
     assert not view.modal.is_displayed
@@ -36,7 +48,7 @@ def test_generic_modal(browser):
     view.flush_widget_cache()
     wait_for(lambda: not view.modal.is_displayed, delay=0.5, num_sec=5)
 
-    # # open modal again
+    # open modal again
     view.button.click()
     wait_for(lambda: view.modal.is_displayed, delay=0.5, num_sec=5)
     # make sure buttons are not disabled
@@ -44,5 +56,14 @@ def test_generic_modal(browser):
     assert not view.modal.footer.accept.disabled
     # make sure the cancel button works
     view.modal.dismiss()
+    wait_for(lambda: not view.modal.is_displayed, delay=0.1, num_sec=5)
 
+    # open modal to fill the form
+    view.button.click()
+    wait_for(lambda: view.modal.is_displayed, delay=0.5, num_sec=5)
+    assert view.fill(
+        {"modal": {"body": {"field_one": "value1", "field_two": "value2", "field_three": "value3"}}}
+    )
+    # make sure accept button works
+    view.modal.accept()
     wait_for(lambda: not view.modal.is_displayed, delay=0.1, num_sec=5)

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -726,42 +726,43 @@ document.getElementById("kebab_display").innerHTML = actionOne;
       </div>
     </div>
    </div></div><!-- /container -->
-   <button class="btn btn-default" data-toggle="modal" data-target="#myModal">Launch demo modal</button>
-<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
-          <span class="pficon pficon-close"></span>
-        </button>
-        <h4 class="modal-title" id="myModalLabel">Modal Title</h4>
-      </div>
-      <div class="modal-body">
-        <form class="form-horizontal">
-          <div class="form-group">
-            <label class="col-sm-3 control-label" for="textInput-modal-markup">Field One</label>
-            <div class="col-sm-9">
-              <input type="text" id="textInput-modal-markup" class="form-control"></div>
-          </div>
-          <div class="form-group">
-            <label class="col-sm-3 control-label" for="textInput2-modal-markup">Field Two</label>
-            <div class="col-sm-9">
-              <input type="text" id="textInput2-modal-markup" class="form-control"></div>
-          </div>
-          <div class="form-group">
-            <label class="col-sm-3 control-label" for="textInput3-modal-markup">Field Three</label>
-            <div class="col-sm-9">
-              <input type="text" id="textInput3-modal-markup" class="form-control">
+  <!-- Modal ---->
+  <button class="btn btn-default" data-toggle="modal" data-target="#myModal">Launch demo modal</button>
+  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+            <span class="pficon pficon-close"></span>
+          </button>
+          <h4 class="modal-title" id="myModalLabel">Modal Title</h4>
+        </div>
+        <div class="modal-body">
+          <form class="form-horizontal">
+            <div class="form-group">
+              <label class="col-sm-3 control-label" for="textInput-modal-markup">Field One</label>
+              <div class="col-sm-9">
+                <input type="text" id="textInput-modal-markup" class="form-control"></div>
             </div>
-          </div>
-        </form>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary">Save</button>
+            <div class="form-group">
+              <label class="col-sm-3 control-label" for="textInput2-modal-markup">Field Two</label>
+              <div class="col-sm-9">
+                <input type="text" id="textInput2-modal-markup" class="form-control"></div>
+            </div>
+            <div class="form-group">
+              <label class="col-sm-3 control-label" for="textInput3-modal-markup">Field Three</label>
+              <div class="col-sm-9">
+                <input type="text" id="textInput3-modal-markup" class="form-control">
+              </div>
+            </div>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+          <button id="save" type="button" class="btn btn-primary" data-dismiss="modal">Save</button>
+        </div>
       </div>
     </div>
-  </div>
-</div>
+  </div> <!--- Modal ---->
 </body>
 </html>

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -726,5 +726,42 @@ document.getElementById("kebab_display").innerHTML = actionOne;
       </div>
     </div>
    </div></div><!-- /container -->
+   <button class="btn btn-default" data-toggle="modal" data-target="#myModal">Launch demo modal</button>
+<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+          <span class="pficon pficon-close"></span>
+        </button>
+        <h4 class="modal-title" id="myModalLabel">Modal Title</h4>
+      </div>
+      <div class="modal-body">
+        <form class="form-horizontal">
+          <div class="form-group">
+            <label class="col-sm-3 control-label" for="textInput-modal-markup">Field One</label>
+            <div class="col-sm-9">
+              <input type="text" id="textInput-modal-markup" class="form-control"></div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-3 control-label" for="textInput2-modal-markup">Field Two</label>
+            <div class="col-sm-9">
+              <input type="text" id="textInput2-modal-markup" class="form-control"></div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-3 control-label" for="textInput3-modal-markup">Field Three</label>
+            <div class="col-sm-9">
+              <input type="text" id="textInput3-modal-markup" class="form-control">
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
Adding a modal widget and a unit test to accompany it: 

https://www.patternfly.org/pattern-library/widgets/#modal

Since the form that is present in the modal can be general, the unit test provides an example use case for dealing with this. The `SpecificModal` inherits the `Modal` class and then overwrites the `body` widget. 
 