### PR TITLE
[1LP][RFR] Fix is_displayed for about modal

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -1888,11 +1888,10 @@ class AboutModal(Widget):
     @property
     def is_open(self):
         """Is the about modal displayed right now"""
-        return 'in' in self.browser.classes(self)
-
-    @property
-    def is_displayed(self):
-        return self.is_open
+        try:
+            return 'in' in self.browser.classes(self)
+        except NoSuchElementException:
+            return False
 
     def close(self):
         """Close the modal"""


### PR DESCRIPTION
**Changes:**
1. Remove `is_displayed` from `AboutModal` and use the parent is_displayed instead.
2. Wrap `is_open` code within a try and catch block because if the modal is not opened `is_open` raises `NoSuchElementException`.