### PR TITLE
[1LP][RFR] Add partial_match in BootstrapNav is_disabled method

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -562,6 +562,9 @@ class BootstrapNav(Widget):
         """Check if an item is disabled"""
         if text:
             # Check if an item is disabled based on the text of that item
+            if isinstance(text, partial_match):
+                partial_text = text.item
+                text = self.browser.element(self.PARTIAL_TEXT.format(txt=quote(partial_text))).text
             xpath = self.TEXT_DISABLED.format(txt=quote(text))
         elif self.VALID_ATTRS & set(kwargs.keys()):
             # Check if an item is disabled based on an attribute, if it is one of the VALID_ATTRS

--- a/testing/test_bootstrap_nav.py
+++ b/testing/test_bootstrap_nav.py
@@ -1,3 +1,4 @@
+from widgetastic.utils import partial_match
 from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapNav
 
@@ -11,8 +12,16 @@ def test_bootstrap_nav(browser):
     # assert that nav is visible
     assert view.nav.is_displayed
     # Check if all options are being returned
-    assert view.nav.all_options == ['ALL (Default)', 'Environment / Dev', 'Environment / Prod', '']
+    assert view.nav.all_options == [
+        "ALL (Default)",
+        "Environment / Dev",
+        "Environment / Prod",
+        "Environment / UAT",
+        "",
+    ]
     # assert if currently active(selected) element is being returned correctly
     assert view.nav.read() == ['ALL (Default)']
     # assert if list has_item
     assert view.nav.has_item(text='Environment / Prod')
+    # assert if partial match works for is_disabled
+    assert view.nav.is_disabled(text=partial_match("UAT"))

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -776,6 +776,9 @@ document.getElementById("kebab_display").innerHTML = actionOne;
       <li class="">
         <a href="#">Environment / Prod</a>
       </li>
+      <li class="disabled">
+        <a href="#">Environment / UAT</a>
+      </li>
       <li class="">
         <a href="#"></a>
       </li>


### PR DESCRIPTION
- Add the ability to pass a partial_match text to BootstrapNav's is_disabled.

Require this change for integration_tests [PR#9266](https://github.com/ManageIQ/integration_tests/pull/9266).