### PR TITLE
[RFR] Raise WidgetOperationFailed instead of StopIteration in breadcrumb

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,7 @@
-[bdist_wheel]
-universal=1
-
 [options]
 install_requires =
     widgetastic.core
-    aenum==2.1.2
+    aenum==2.2.1
 setup_requires = setuptools_scm
 package_dir =
     =src

--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -2028,7 +2028,11 @@ class BreadCrumb(Widget):
 
     def click_location(self, name, handle_alert=True):
         br = self.browser
-        location = next(loc for loc in self._path_elements if br.text(loc) == name)
+        try:
+            location = next(loc for loc in self._path_elements if br.text(loc) == name)
+        except StopIteration:
+            self.logger.exception(f'Given location name [{name}] not found')
+            raise WidgetOperationFailed('Unable to click breadcrumb location, location not found')
         result = br.click(br.element(self.LINK, parent=location), ignore_ajax=handle_alert)
         if handle_alert:
             self.browser.handle_alert(wait=2.0, squash=True)


### PR DESCRIPTION
click_location can raise StopIteration, I think its a lot better to raise WidgetOperationFailed