### PR TITLE
[RFR] Add regex capability to match_messages

### DIFF
--- a/testing/test_flashmessages.py
+++ b/testing/test_flashmessages.py
@@ -1,0 +1,44 @@
+import re
+from collections import namedtuple
+
+from widgetastic.widget import View
+from widgetastic_patternfly import FlashMessages
+
+Message = namedtuple('Message', 'text type')
+
+MSGS = [Message('Retirement date set to 12/31/19 15:55 UTC', 'success'),
+        Message('Retirement date removed', 'success'),
+        Message('All changes have been reset', 'warning'),
+        Message('Set/remove retirement date was cancelled by the user', 'success'),
+        Message('Retirement initiated for 1 VM and Instance from the CFME Database', 'success')]
+
+
+def test_flashmessage(browser):
+    class TestView(View):
+        flash = FlashMessages('.//div[@id="flash_msg_div"]')
+
+    view = TestView(browser)
+    msgs = view.flash.read()
+    assert len(msgs) == len(MSGS)
+    for i in range(len(msgs)):
+        assert msgs[i] == MSGS[i].text
+
+    view.flash.assert_no_error()
+
+    # regex match
+    t = re.compile('^Retirement')
+    view.flash.assert_message(t)
+    view.flash.assert_success_message(t)
+
+    # partial match
+    t = 'etirement'
+    view.flash.assert_message(t, partial=True)
+    view.flash.assert_success_message(t, partial=True)
+
+    # inverse match
+    t = 'This message does not exist'
+    assert not view.flash.match_messages(t)
+    assert view.flash.match_messages(t, inverse=True)
+
+    view.flash.dismiss()
+    assert not view.flash.read()

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -76,7 +76,7 @@
   </div>
 
 
-<!--------------------------------- Bootstrap-Datepicker------------------------------------------>
+  <!--------------------------------- Bootstrap-Datepicker------------------------------------------>
   <div class="datepicker_container" align="center" style="width: 300px; text-align:center">
     <div class="datepicker_readonly">
       <label class="control-label " for="date_readonly">
@@ -126,11 +126,11 @@
       });
   })
   </script>
-<!--------------------------------- Bootstrap-Datepicker End ------------------------------------>
+  <!--------------------------------- Bootstrap-Datepicker End ------------------------------------>
 
-<!--------------------------------- AggregateStatusCard ------------------------------------------>
-<!-- from reference
-markup: https://www.patternfly.org/pattern-library/cards/aggregate-status-card/#example-code-1 -->
+  <!--------------------------------- AggregateStatusCard ------------------------------------------>
+  <!-- from reference
+  markup: https://www.patternfly.org/pattern-library/cards/aggregate-status-card/#example-code-1 -->
   <div class="cards-pf">
     <div class="container-fluid container-cards-pf">
       <div class="row row-cards-pf">
@@ -785,5 +785,54 @@ document.getElementById("kebab_display").innerHTML = actionOne;
     </ul>
   </div>
   <!--End BootstrapNav------------------------------------->
+  <!--Begin FlashMessages------------------------------------->
+  <div id="flash_msg_div" style="">
+    <div class="flash_text_div">
+      <div class="alert alert-success alert-dismissable">
+        <button class="close" data-dismiss="alert">
+          <span class="pficon pficon-close"></span>
+        </button>
+        <span class="pficon pficon-ok"></span>
+        <strong>Retirement date set to 12/31/19 15:55 UTC</strong>
+      </div>
+    </div>
+    <div class="flash_text_div">
+      <div class="alert alert-success alert-dismissable">
+        <button class="close" data-dismiss="alert">
+          <span class="pficon pficon-close"></span>
+        </button>
+        <span class="pficon pficon-ok"></span>
+        <strong>Retirement date removed</strong>
+      </div>
+    </div>
+    <div class="flash_text_div">
+      <div class="alert alert-warning">
+        <button class="close" data-dismiss="alert">
+          <span class="pficon pficon-close"></span>
+        </button>
+        <span class="pficon pficon-warning-triangle-o"></span>
+        <strong>All changes have been reset</strong>
+      </div>
+    </div>
+    <div class="flash_text_div">
+      <div class="alert alert-success alert-dismissable">
+        <button class="close" data-dismiss="alert">
+          <span class="pficon pficon-close"></span>
+        </button>
+        <span class="pficon pficon-ok"></span>
+        <strong>Set/remove retirement date was cancelled by the user</strong>
+      </div>
+    </div>
+    <div class="flash_text_div">
+      <div class="alert alert-success alert-dismissable">
+        <button class="close" data-dismiss="alert">
+          <span class="pficon pficon-close"></span>
+        </button>
+        <span class="pficon pficon-ok"></span>
+        <strong>Retirement initiated for 1 VM and Instance from the CFME Database</strong>
+      </div>
+    </div>
+  </div>
+  <!--End FlashMessages------------------------------------->
 </body>
 </html>


### PR DESCRIPTION
This PR adds the ability to pass a compiled regex as the 'text' parameter for the match_messages, assert_message, and assert_success_message methods of the FlashMessages class.

For example, when testing VM retirement using the 'Time Delay from Now' option, the selected month/week/day/hour time delay values will be added to the date/time at which the page was loaded. The resulting flash message from a successful save is of the form "Retirement date set to 12/19/19 18:31 UTC". But if the time changes from one minute to the next while navigating to the Set Retirement Date page, it is impossible to predict accurately whether the flash message will display a time delay calculated from one or the other minute. Now, with a test like the following, 

```
    flash_regex = re.compile(f"^Retirement date set to (12/19/19 18:31 UTC|12/19/19 18:32 UTC)$")
    view.flash.assert_success_message(flash_regex)
```

a single assertion against a range of dates / flash message texts can be performed.

A couple other small changes:
1.) Fixed several typos in which log messages wrote 'Boostrap tree' instead of 'Bootstrap tree'.
2.) Changed the logging in match_messages somewhat to make it clearer and to indicate when the match is actually an inverse match.
3.) Also added a unit test file, test_flashmessages.py, which tests basic functionality of the FlashMessages methods read, assert_no_error, assert_message, assert_success_message, match_messages, and dismiss.