### PR TITLE
[RFR] Use XPath instead of Selenium WebElements for FlashMessage locator

### DIFF
--- a/testing/test_flashmessages.py
+++ b/testing/test_flashmessages.py
@@ -15,7 +15,7 @@ MSGS = [Message('Retirement date set to 12/31/19 15:55 UTC', 'success'),
 
 def test_flashmessage(browser):
     class TestView(View):
-        flash = FlashMessages('.//div[@id="flash_msg_div"]')
+        flash = View.nested(FlashMessages)
 
     view = TestView(browser)
     msgs = view.flash.read()
@@ -25,20 +25,19 @@ def test_flashmessage(browser):
 
     view.flash.assert_no_error()
 
-    # regex match
+    # Test regex match.
     t = re.compile('^Retirement')
     view.flash.assert_message(t)
     view.flash.assert_success_message(t)
 
-    # partial match
+    # Test partial pattern match.
     t = 'etirement'
     view.flash.assert_message(t, partial=True)
     view.flash.assert_success_message(t, partial=True)
 
-    # inverse match
+    # Test inverse pattern match.
     t = 'This message does not exist'
-    assert not view.flash.match_messages(t)
-    assert view.flash.match_messages(t, inverse=True)
+    assert view.flash.read(text=t, inverse=True) == msgs
 
     view.flash.dismiss()
     assert not view.flash.read()

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -798,8 +798,6 @@ document.getElementById("kebab_display").innerHTML = actionOne;
         <span class="pficon pficon-ok"></span>
         <strong>Retirement date set to 12/31/19 15:55 UTC</strong>
       </div>
-    </div>
-    <div class="flash_text_div">
       <div class="alert alert-success alert-dismissable">
         <button class="close" data-dismiss="alert">
           <span class="pficon pficon-close"></span>
@@ -807,8 +805,6 @@ document.getElementById("kebab_display").innerHTML = actionOne;
         <span class="pficon pficon-ok"></span>
         <strong>Retirement date removed</strong>
       </div>
-    </div>
-    <div class="flash_text_div">
       <div class="alert alert-warning">
         <button class="close" data-dismiss="alert">
           <span class="pficon pficon-close"></span>
@@ -816,8 +812,6 @@ document.getElementById("kebab_display").innerHTML = actionOne;
         <span class="pficon pficon-warning-triangle-o"></span>
         <strong>All changes have been reset</strong>
       </div>
-    </div>
-    <div class="flash_text_div">
       <div class="alert alert-success alert-dismissable">
         <button class="close" data-dismiss="alert">
           <span class="pficon pficon-close"></span>
@@ -825,8 +819,6 @@ document.getElementById("kebab_display").innerHTML = actionOne;
         <span class="pficon pficon-ok"></span>
         <strong>Set/remove retirement date was cancelled by the user</strong>
       </div>
-    </div>
-    <div class="flash_text_div">
       <div class="alert alert-success alert-dismissable">
         <button class="close" data-dismiss="alert">
           <span class="pficon pficon-close"></span>


### PR DESCRIPTION
The FlashMessage class currently uses Selenium WebElements to implement its widget locator:

```
class FlashMessages(Widget):
    @property
    def messages(self):
        result = []
        msg_xpath = ('.//div[@id="flash_text_div" or '
                     'contains(@class, "flash_text_div")]/div[contains(@class, "alert")]')
        try:

            for flash_div in self.browser.elements(msg_xpath, parent=self, check_visibility=True):
                result.append(FlashMessage(self, flash_div, logger=self.logger))

class FlashMessage(Widget):
    def __init__(self, parent, flash_div, logger=None):
        Widget.__init__(self, parent, logger=logger)
        self.flash_div = flash_div

    def __locator__(self):
        return self.flash_div
```

This results in warnings logged to cfme.log any time a FlashMessage is read, e.g.,

```
2019-12-11 10:24:20,477 [I] [cfme] [RequestsView/flash]: Performing exact match of flash messages, text: 'Retirement initiated for 1 VM and Instance from the CFME Database', type: 'success' (.cfme_venv/lib64/python3.7/site-packages/widgetastic_patternfly/__init__.py:315)
2019-12-11 10:24:20,620 [W] [cfme] [RequestsView/flash]: __locator__ of FlashMessage class returns a WebElement! (.cfme_venv/lib64/python3.7/site-packages/widgetastic/widget/base.py:341)
```

This PR re-implements FlashMessages as a View containing FlashMessage as a ParametrizedView, to use XPath locators instead. Each FlashMessage is indexed by the XPath index of the message within the containing FlashMessages block.

Because the user can dismiss these messages in random order, this XPath index is not necessarily fixed. For example, if there are three messages on the page,

text: "Message A", locator: (msg_xpath)[1]
text: "Message B", locator: (msg_xpath)[2]
text: "Message C", locator: (msg_xpath)[3]

and the user dismisses the one with text "Message A", then the remaining messages will now have new locators:

text: "Message B", locator: (msg_xpath)[1]
text: "Message C", locator: (msg_xpath)[2]

To account for this, FlashMessages.messages yields the individual FlashMessage instances one at a time, and the XPath index of the next message is re-calculated in case of message dismissal.

Views that use FlashMessages will need to be updated since it is no longer a Widget:

```
- flash = FlashMessages('.//div[@id="flash_msg_div"]')
+ flash = View.nested(FlashMessages)
```
