### PR TITLE
[RFR] Add NoSuchElementException handling back into FlashMessages.

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -889,7 +889,7 @@ class BootstrapSelect(Widget, ClickableMixin):
                 self.logger.info('selecting by visible text: %r', item)
                 try:
                     self.browser.click(self.BY_VISIBLE_TEXT.format(quote(item)),
-                                       parent=self,  force_scroll=True)
+                                       parent=self, force_scroll=True)
                 except NoSuchElementException:
                     try:
                         # Added this as for some views(some tags pages) dropdown is separated from
@@ -2818,7 +2818,12 @@ class FlashMessages(View):
 
     @property
     def msg_count(self):
-        return len(self.browser.elements(self.MSG_LOCATOR, parent=self))
+        c = 0
+        try:
+            c = len(self.browser.elements(self.MSG_LOCATOR, parent=self))
+        except NoSuchElementException:
+            pass
+        return c
 
     def messages(self, **msg_filter):
         """Return a generator for all notifications matching the msg_filter.


### PR DESCRIPTION
In the older Widget-based implementation of FlashMessages, there was silent catching of NoSuchElementException if there was no flash message block found on the page:

```
    @property
    def messages(self):
        result = []
        msg_xpath = ('.//div[@id="flash_text_div" or '
                     'contains(@class, "flash_text_div")]/div[contains(@class, "alert")]')
        try:

            for flash_div in self.browser.elements(msg_xpath, parent=self, check_visibility=True):
                result.append(FlashMessage(self, flash_div, logger=self.logger))
        except NoSuchElementException:
            pass
        return result
```
The newer View-based implementation refactored the message lookup to use a generator, and ended up dropping this exception handling. This PR restores it, in the msg_count property that gets called by the generator to look up the number of flash messages present. Now, if a view contains a nested FlashMessages view that does not actually get displayed, calls to methods like view.flash.assert_no_error() will succeed instead of erroring out like this:

```
E           selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator='.//div[@id="flash_msg_div"]')
```
