### PR TITLE
[RFR] Do not ignore failures

### DIFF
--- a/testing/test_modal.py
+++ b/testing/test_modal.py
@@ -4,10 +4,18 @@ from wait_for import wait_for
 from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic_patternfly import Modal, Button
+from time import sleep
 
 # Values from testing_page.html modal
 modal_id = 'myModal'
 title = 'Modal Title'
+
+
+MODAL_INTERACTION_TIMEOUT = 5
+
+
+def workaround_modal_close_n_open_timing_issue():
+    sleep(.1)
 
 
 class SpecificModal(Modal):
@@ -39,25 +47,32 @@ def test_generic_modal(browser):
     # Open the modal
     assert not view.button.disabled
     view.button.click()
-    wait_for(lambda: view.modal.is_displayed, delay=0.5, num_sec=5)
+    wait_for(lambda: view.modal.is_displayed,
+             delay=0.5, num_sec=MODAL_INTERACTION_TIMEOUT)
 
     assert view.modal.title == title
 
     # close the modal via the "x"
     view.modal.close()
     view.flush_widget_cache()
-    wait_for(lambda: not view.modal.is_displayed, delay=0.5, num_sec=5)
+    wait_for(lambda: not view.modal.is_displayed,
+             delay=0.5, num_sec=MODAL_INTERACTION_TIMEOUT)
+
+    workaround_modal_close_n_open_timing_issue()
 
     # open modal again
     view.button.click()
-    wait_for(lambda: view.modal.is_displayed, delay=0.5, num_sec=5)
+    wait_for(lambda: view.modal.is_displayed,
+             delay=0.5, num_sec=MODAL_INTERACTION_TIMEOUT)
     # make sure buttons are not disabled
     assert not view.modal.footer.dismiss.disabled
     assert not view.modal.footer.accept.disabled
     # make sure the cancel button works
     view.modal.dismiss()
-    wait_for(lambda: not view.modal.is_displayed, delay=0.1, num_sec=5)
+    wait_for(lambda: not view.modal.is_displayed,
+             delay=0.1, num_sec=MODAL_INTERACTION_TIMEOUT)
 
+    workaround_modal_close_n_open_timing_issue()
     # open modal to fill the form
     view.button.click()
     wait_for(lambda: view.modal.is_displayed, delay=0.5, num_sec=5)
@@ -66,4 +81,5 @@ def test_generic_modal(browser):
     )
     # make sure accept button works
     view.modal.accept()
-    wait_for(lambda: not view.modal.is_displayed, delay=0.1, num_sec=5)
+    wait_for(lambda: not view.modal.is_displayed,
+             delay=0.1, num_sec=MODAL_INTERACTION_TIMEOUT)

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ deps =
     pytest-cov
     selenium
 commands =
-    - py.test {posargs: -v --cov widgetastic_patternfly --cov-report term-missing --alluredir allure/}
-    - coveralls
+    py.test {posargs: -v --cov widgetastic_patternfly --cov-report term-missing --alluredir allure/}
+    coveralls
 
 [testenv:codechecks]
 skip_install = true


### PR DESCRIPTION
The `- ` works as squelching of the nonzero exit statuses. We do not want this. Fixing that.

Also working around a problem with modal window opening right after it was closed, happening only on chrome. It will not reopen. This should be investigated.