### PR TITLE
[RFR] Use pytest_httpserver instead of pytest-localserver

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -47,10 +47,11 @@ def browser(selenium, httpserver, request):
     this_module = sys.modules[__name__]
     path = os.path.dirname(this_module.__file__)
     testfilename = path + '/testing_page.html'
-    httpserver.serve_content(
+    server_root = '/'
+    httpserver.expect_request(server_root).respond_with_data(
         codecs.open(testfilename, mode='r', encoding='utf-8').read(),
         headers=[('Content-Type', 'text/html')])
-    selenium.get(httpserver.url)
+    selenium.get(httpserver.url_for(server_root))
     return CustomBrowser(selenium)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,12 @@
 envlist = py{36,37},codechecks
 
 [testenv]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH BROWSER
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH BROWSER PYTEST_HTTPSERVER_HOST PYTEST_HTTPSERVER_PORT
 deps =
     allure-pytest
     coveralls
     pytest
-    pytest-localserver
+    pytest_httpserver
     pytest-cov
     selenium
 commands =


### PR DESCRIPTION
Changing the localserver to pytest_httpserver to allow running the tests on different machine than the browser is running on (a selenium container) (this allows to set host and port to listen on
with PYTEST_HTTPSERVER_HOST PYTEST_HTTPSERVER_PORT env vars).

It would probably good to merge https://github.com/RedHatQE/widgetastic.patternfly/pull/122 first to remove ignoring of the failing tests.

