### PR TITLE
Error handling flash dismiss

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -2906,10 +2906,21 @@ class FlashMessages(View):
             result.append(msg.text)
         return result
 
-    def dismiss(self):
+    def dismiss(self, handle_exception=True):
         """Dismiss all notifications."""
         for msg in self.messages():
-            msg.dismiss()
+            # Handle a NoSuchElement or StaleElementReference
+            # Some designs will have messages that clear themselves while we're iterating
+            try:
+                msg.dismiss()
+            except (NoSuchElementException, StaleElementReferenceException):
+                self.logger.exception(
+                    f'Exception dismissing messages on ${msg}, continuing'
+                )
+                if handle_exception:
+                    continue
+                else:
+                    raise
 
     def assert_no_error(self):
         self.logger.info("Asserting there are no error notifications.")

--- a/testing/test_flashmessages.py
+++ b/testing/test_flashmessages.py
@@ -1,6 +1,10 @@
 import re
 from collections import namedtuple
+from unittest import mock
 
+import pytest
+
+from widgetastic.exceptions import NoSuchElementException
 from widgetastic.widget import View
 from widgetastic_patternfly import FlashMessages
 
@@ -41,3 +45,22 @@ def test_flashmessage(browser):
 
     view.flash.dismiss()
     assert not view.flash.read()
+
+
+def test_flash_message_dismiss_exception(browser, request):
+    class TestView(View):
+        flash = View.nested(FlashMessages)
+
+    view = TestView(browser)
+
+    def _dismiss_exception(self):
+        raise NoSuchElementException('dummy exception')
+
+    from widgetastic_patternfly import FlashMessage
+    with mock.patch.object(FlashMessage, 'dismiss', _dismiss_exception) as patcher:
+
+        with pytest.raises(NoSuchElementException, match='dummy exception'):
+            view.flash.dismiss(handle_exception=False)
+
+        # no exception should be raised
+        view.flash.dismiss(handle_exception=True)


### PR DESCRIPTION
On some applications, flash messages may dismiss themselves between WT creating the FlashMessage instance, and trying to delete it

This defaults the dismiss method to log and squash NoSuchElement and StaleElementReference exceptions.

Includes unit tests