### PR TITLE
fixed the modal test, resolved #126 Issue  

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -1808,13 +1808,16 @@ class Modal(View):
 
     def __init__(self, parent, id=None, logger=None):
         self.id = id
-        if id:
-            self.ROOT = ParametrizedLocator(
-                './/div[normalize-space(@id)={@id|quote} and '
-                'contains(@class, "modal") and contains(@class, "fade") '
-                'and @role="dialog"]')
-
         View.__init__(self, parent, logger=logger)
+
+    def __locator__(self):
+        """If id was passed, parametrize it into a locator, otherwise use ROOT"""
+        if self.id is not None:
+            return ('//div[normalize-space(@id)="{}" and contains(@class, "modal")'
+                    'and contains(@class, "fade") and @role="dialog"]'
+                    .format(self.id))
+        else:
+            return self.ROOT
 
     @property
     def title(self):


### PR DESCRIPTION
Fixed https://github.com/RedHatQE/widgetastic.patternfly/issues/126

### Test Result 
```
========================================================= test session starts ==========================================================
platform linux -- Python 3.7.3, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
cachedir: .tox/py37/.pytest_cache
rootdir: /home/okhatavk/Learning/widgetastic.patternfly
plugins: httpserver-0.3.6, cov-2.10.1, allure-pytest-2.8.19
collected 100 items / 99 deselected / 1 selected                                                                                       

testing/test_modal.py 
-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================================== 1 passed, 99 deselected, 1 warning in 92.26s (0:01:32) ========================================
```
_
