### PR TITLE
Wrap FlashMessages methods with new retry_element decorator

### DIFF
--- a/testing/test_flashmessages.py
+++ b/testing/test_flashmessages.py
@@ -45,22 +45,3 @@ def test_flashmessage(browser):
 
     view.flash.dismiss()
     assert not view.flash.read()
-
-
-def test_flash_message_dismiss_exception(browser, request):
-    class TestView(View):
-        flash = View.nested(FlashMessages)
-
-    view = TestView(browser)
-
-    def _dismiss_exception(self):
-        raise NoSuchElementException('dummy exception')
-
-    from widgetastic_patternfly import FlashMessage
-    with mock.patch.object(FlashMessage, 'dismiss', _dismiss_exception) as patcher:
-
-        with pytest.raises(NoSuchElementException, match='dummy exception'):
-            view.flash.dismiss(handle_exception=False)
-
-        # no exception should be raised
-        view.flash.dismiss(handle_exception=True)


### PR DESCRIPTION
This PR decorates the `dismiss()` and `read()` methods in `FlashMessages` with a new method, `retry_element`. Any method decorated with `retry_element` will run up to some maximum number of tries, if `NoSuchElementException` or `StaleElementReferenceException` are raised. This is similar to the `retry_stale_element` method in https://github.com/RedHatQE/widgetastic.core/blob/cf0fe853dee3b41839fdecf00a0e5a53660109eb/src/widgetastic/utils.py#L682 , which only checks for the latter exception.

This type of exception handling is needed because individual notifications may auto-dismiss after a couple seconds, and if all notifications auto-dismiss, then the notification list element (`FlashMessages.ROOT`) may itself disappear, leading to exceptions if `read()` or `dismiss()` are running at that time.

Any attempt to use `messages()` or `__getitem__()` (e.g., `view.flash[0]`), which return or yield individual `FlashMessage` instances, still has the potential for stale or missing element exceptions, and any external code that uses them directly will still need to handle these exceptions.

Travis CI build failures are unrelated to this PR.

Fixes https://github.com/SatelliteQE/airgun/issues/554