### PR TITLE
Add ignore_messages option to assert_no_error

### DIFF
--- a/src/widgetastic_patternfly/__init__.py
+++ b/src/widgetastic_patternfly/__init__.py
@@ -2925,11 +2925,19 @@ class FlashMessages(View):
         for msg in self.messages():
             msg.dismiss()
 
-    def assert_no_error(self):
+    def assert_no_error(self, ignore_messages=None):
+        """Assert no error messages present.
+
+        Kwargs:
+               ignore_messages: :py:class:`list` of notification text to ignore. Default: None
+        """
+        if ignore_messages is None:
+            ignore_messages = []
+        msg_filter = {"t": {"success", "info", "warning"}, "inverse": True}
+
         self.logger.info("Asserting there are no error notifications.")
-        msg_filter = {'t': {'success', 'info', 'warning'}, 'inverse': True}
         errs = self.read(**msg_filter)
-        if errs:
+        if set(errs) - set(ignore_messages):
             self.logger.error(errs)
             raise AssertionError(f"assert_no_error: found error notifications {errs}")
 

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -833,6 +833,13 @@ document.getElementById("kebab_display").innerHTML = actionOne;
         <span class="pficon pficon-ok"></span>
         <strong>Retirement initiated for 1 VM and Instance from the CFME Database</strong>
       </div>
+      <div class="alert alert-danger alert-dismissable">
+        <button class="close" data-dismiss="alert">
+          <span class="pficon pficon-close"></span>
+        </button>
+        <span class="pficon pficon-error-circle-o"></span>
+        <strong>Not Configured</strong>
+      </div>
     </div>
   </div>
   <!--End FlashMessages------------------------------------->


### PR DESCRIPTION
This PR adds the argument `ignore_messages` to `FlashMessages.assert_no_error()`. This allows the user to pass a list of message text values that should be ignored when checking for all error messages, and an `AssertionError` will not be raised if there are no other error messages.