### PR TITLE
Remove aenum dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,7 @@ classifiers=
 [options]
 python_requires = >= 3.8
 install_requires =
-    widgetastic.core
-    aenum==3.1.8
+    widgetastic.core>=1.0.0
 setup_requires = setuptools_scm
 package_dir =
     =src

--- a/src/widgetastic_patternfly/utils.py
+++ b/src/widgetastic_patternfly/utils.py
@@ -1,8 +1,8 @@
 # module for patternfly utility classes and methods
-from aenum import Constant
+from enum import Enum
 
 
-class IconConstants(Constant):
+class IconConstants(Enum):
     """class to hold just the icon constants
 
     References:
@@ -27,8 +27,8 @@ class IconConstants(Constant):
     USER = "pficon-user"
 
     @classmethod
-    def icon_strings(cls):
-        return {a: s for a, s in vars(IconConstants).items() if isinstance(s, Constant)}
+    def icon_enums(cls):
+        return {a: s for a, s in vars(IconConstants).items() if isinstance(s, Enum)}
 
 
 class PFIcon:
@@ -51,7 +51,6 @@ class PFIcon:
         Raises:
             widgetastic.exceptions.NoSuchElementException when no icon span found
         """
-
         els = browser.elements(
             './/*[contains(@class, "pficon") or contains(@class, "fa")]', parent=element
         )
@@ -65,7 +64,7 @@ class PFIcon:
         icon_name = icon_class.pop() if icon_class else None
         icons = [
             getattr(cls.icons, attr, None)
-            for attr, icon_string in cls.icons.icon_strings().items()
-            if icon_string == icon_name
+            for attr, icon_string in cls.icons.icon_enums().items()
+            if icon_string.value == icon_name
         ]
         return icons.pop() if icons else None


### PR DESCRIPTION
Using standard python enums requires referencing name/value attribute
directly, which aenum.Constant made a bit easier.

I'd rather not have the dependency, and update callers to use
PFIcon.icons new enums.

Downstream dependency wise, airgun isn't using PFIcon directly, and neither is insights-qe.